### PR TITLE
Update release.yml for overwriting asset zips

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,8 @@ jobs:
             for p in plugins:
               print(p)
               os.chdir('Working/All Plugins/')
-              subprocess.run(["zip", "-r", "../../" + p + ".zip", p],
+              corrected = p.replace(" ", ".")
+              subprocess.run(["zip", "-r", "../../" + corrected + ".zip", p],
                 stdout=subprocess.DEVNULL)
               os.chdir('../../')
           else:


### PR DESCRIPTION
Replaces space in folder names with a dot for the zip, so that the release action don't fail with mismatching filenames.