### PR TITLE
news rework

### DIFF
--- a/res/config.txt
+++ b/res/config.txt
@@ -5,3 +5,4 @@ pathtoplugins = Working/
 webroot = https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/
 pluginurl = https://github.com/Hecter94/EndlessSky-PluginArchive/tree/main/Working/
 assetfullpath = https://github.com/Hecter94/EndlessSky-PluginArchive/releases/download/Latest/
+newscount = 15

--- a/res/news.txt
+++ b/res/news.txt
@@ -57,27 +57,3 @@
 2023-07-07 | Derogam | updated <br>
 2023-07-07 | Galaxias | updated <br>
 2023-06-28 | galactic.capital.investment | updated <br>
-2023-06-23 | galactic.capital.investment | updated <br>
-2023-06-22 | galactic.capital.investment | updated <br>
-2023-06-21 | too.many.asteroids | updated <br>
-2023-06-21 | additional.command.buttons | updated <br>
-2023-06-21 | snowfeather.robotics | updated <br>
-2023-06-20 | galactic.capital.investment | updated <br>
-2023-06-20 | automata.destruction.75percent | updated <br>
-2023-06-20 | automata.destruction.0percent | updated <br>
-2023-06-20 | kor.efret.shipyard | updated <br>
-2023-06-20 | unique.fix | updated <br>
-2023-06-20 | more.boarding.missions | updated <br>
-2023-06-20 | automata.destruction.51percent | updated <br>
-2023-06-20 | automata.in.human.space | updated <br>
-2023-06-20 | automata.destruction.23percent | updated <br>
-2023-06-19 | galactic.capital.investment | updated <br>
-2023-06-19 | automata.destruction.75percent | updated <br>
-2023-06-19 | automata.destruction.0percent | updated <br>
-2023-06-19 | kor.efret.shipyard | updated <br>
-2023-06-19 | unique.fix | updated <br>
-2023-06-19 | more.boarding.missions | updated <br>
-2023-06-19 | automata.destruction.51percent | updated <br>
-2023-06-19 | automata.in.human.space | updated <br>
-2023-06-19 | automata.destruction.23percent | updated <br>
-2023-06-17 | epo update: directlink and news | updated <br>

--- a/res/news.txt
+++ b/res/news.txt
@@ -1,83 +1,83 @@
-2023-07-15 'Endless-Endless-Sky' updated by 1010Todd | category: [overhauls](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#overhauls)
-2023-07-15 'Midnight Expansion' updated by MidnightPlugins | category: [story](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#story)
-2023-07-15 'Lost in Midnight' updated by MidnightPlugins | category: [story](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#story)
-2023-07-14 'Endless-Endless-Sky' updated by 1010Todd | category: [overhauls](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#overhauls)
-2023-07-14 'Midnight Scrapyard' updated by MidnightPlugins | category: [story](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#story)
-2023-07-14 'Midnight Expansion' updated by MidnightPlugins | category: [story](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#story)
-2023-07-14 'Lost in Midnight' updated by MidnightPlugins | category: [story](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#story)
-2023-07-14 'Enigma Corp High DPI' updated by Amazinite | category: [story](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#story)
-2023-07-14 '-Omnis' updated by Darcy Manoel | category: [cheats](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#cheats)
-2023-07-14 'Ultaka Invasion of Milky Way' updated by 1010Todd | category: [races](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#races)
-2023-07-14 'AES Quarg' updated by Darcy Manoel | category: [races](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#races)
-2023-07-14 'Mining Pinger' updated by Zoura | category: [ships](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#ships)
-2023-07-14 'Fighter Factory' updated by 1010todd | category: [outfits](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#outfits)
-2023-07-14 'AES Irm' updated by Darcy Manoel | category: [races](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#races)
-2023-07-14 'AES Korath' updated by Darcy Manoel | category: [races](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#races)
-2023-07-14 'Mata' updated by Karirawri | category: [races](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#races)
-2023-07-14 'SpaceCrate' updated by Arnan de Gans | category: [story](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#story)
-2023-07-14 'Midnight Expansion' updated by MidnightPlugins | category: [story](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#story)
-2023-07-14 'Low Tech Worlds' updated by dennistribe | category: [races](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#races)
-2023-07-14 'Syndicate Story' updated by leklachu | category: [story](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#story)
-2023-07-14 'AES Aben' updated by Darcy Manoel | category: [races](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#races)
-2023-07-14 'sheragi-rebirth' updated by Petersupes | category: [story](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#story)
-2023-07-13 'Endless-Endless-Sky' updated by 1010Todd | category: [overhauls](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#overhauls)
-2023-07-13 'Amphibious-Ships' updated by Zoura | category: [ships](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#ships)
-2023-07-12 'Lost in Midnight' updated by MidnightPlugins | category: [story](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#story)
-2023-07-11 'Amphibious-Ships' updated by Zoura | category: [ships](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#ships)
-2023-07-09 'Lost in Midnight' updated by MidnightPlugins | category: [story](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#story)
-2023-07-07 'Sounds Of Endless Sky' updated by Sam Gleske | category: [uncategorized](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#uncategorized)
-2023-07-07 'Undisclosed Plugin' updated by petervdmeer | category: [overhauls](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#overhauls)
-2023-07-07 'Coalition-At-War' updated by Josh Mudge | category: [story](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#story)
-2023-07-07 'Endless-Endless-Sky' updated by 1010Todd | category: [overhauls](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#overhauls)
-2023-07-07 'High DPI' updated by Michael Zahniser (Maintained by the ES Community) | category: [graphics](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#graphics)
-2023-07-07 'Portraits for News' updated by Anarchist2 | category: [story](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#story)
-2023-07-07 'sensor' updated by orbitalsupershell | category: [weapons](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#weapons)
-2023-07-07 'Sci-Fi Flavours' updated by Linear Perk | category: [overhauls](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#overhauls)
-2023-07-07 'Arena of the worthy' updated by RisingLeaf | category: [uncategorized](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#uncategorized)
-2023-07-07 'Midnight Scrapyard' updated by MidnightPlugins | category: [story](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#story)
-2023-07-07 'Beyond the Sky' updated by 1010todd | category: [overhauls](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#overhauls)
-2023-07-07 'All Content Plugin' updated by Michael Zahniser | category: [cheats](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#cheats)
-2023-07-07 'Altera' updated by EricD112 | category: [overhauls](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#overhauls)
-2023-07-07 'Outfit Highlighter' updated by Michael Arsollon | category: [graphics](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#graphics)
-2023-07-07 'additional.command.buttons' updated by zuckung | category: [graphics](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#graphics)
-2023-07-07 'Galactic War' updated by 1010todd | category: [overhauls](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#overhauls)
-2023-07-07 'The Evora Navaiya' updated by Polaria1 | category: [races](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#races)
-2023-07-07 'Exporianes' updated by Bereskatuket(Kestrel1110) | category: [races](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#races)
-2023-07-07 'Shirni' updated by Quantumshark | category: [races](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#races)
-2023-07-07 'Play As Sestor' updated by Zoura (AvianGeneticist) | category: [uncategorized](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#uncategorized)
-2023-07-07 'Amphibious-Ships' updated by Zoura | category: [ships](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#ships)
-2023-07-07 'Blended Ships' updated by mOctave | category: [ships](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#ships)
-2023-07-07 'Lemurias Extra ES Stuff' updated by a-random-lemurian | category: [story](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#story)
-2023-07-07 'Mega Freight' updated by 1010todd | category: [ships](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#ships)
-2023-07-07 '40k Pack' updated by 1010Todd | category: [overhauls](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#overhauls)
-2023-07-07 'Space Shuttle Start' updated by MidnightPlugins | category: [story](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#story)
-2023-07-07 'Adamas Project' updated by toiletthings | category: [races](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#races)
-2023-07-07 'World Forge' updated by Amazinite | category: [cheats](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#cheats)
-2023-07-07 'Lost in Midnight' updated by MidnightPlugins | category: [story](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#story)
-2023-07-07 'Derogam' updated by Lorantine | category: [ships](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#ships)
-2023-07-07 'Galaxias' updated by mdpiper | category: [ships](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#ships)
-2023-06-28 'galactic.capital.investment' updated | category: [gameplay](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#gameplay)
-2023-06-23 'galactic.capital.investment' updated
-2023-06-22 'galactic.capital.investment' updated
-2023-06-21 'too.many.asteroids' updated
-2023-06-21 'additional.command.buttons' updated
-2023-06-21 'snowfeather.robotics' updated
-2023-06-20 'galactic.capital.investment' updated
-2023-06-20 'automata.destruction.75percent' updated
-2023-06-20 'automata.destruction.0percent' updated
-2023-06-20 'kor.efret.shipyard' updated
-2023-06-20 'unique.fix' updated
-2023-06-20 'more.boarding.missions' updated
-2023-06-20 'automata.destruction.51percent' updated
-2023-06-20 'automata.in.human.space' updated
-2023-06-20 'automata.destruction.23percent' updated
-2023-06-19 'galactic.capital.investment' updated
-2023-06-19 'automata.destruction.75percent' updated
-2023-06-19 'automata.destruction.0percent' updated
-2023-06-19 'kor.efret.shipyard' updated
-2023-06-19 'unique.fix' updated
-2023-06-19 'more.boarding.missions' updated
-2023-06-19 'automata.destruction.51percent' updated
-2023-06-19 'automata.in.human.space' updated
-2023-06-19 'automata.destruction.23percent' updated
-2023-06-17 repo update: directlink and news
+2023-07-15 | Endless-Endless-Sky | updated <br>
+2023-07-15 | Midnight Expansion | updated <br>
+2023-07-15 | Lost in Midnight | updated <br>
+2023-07-14 | Endless-Endless-Sky | updated <br>
+2023-07-14 | Midnight Scrapyard | updated <br>
+2023-07-14 | Midnight Expansion | updated <br>
+2023-07-14 | Lost in Midnight | updated <br>
+2023-07-14 | Enigma Corp High DPI | updated <br>
+2023-07-14 | -Omnis | updated <br>
+2023-07-14 | Ultaka Invasion of Milky Way | updated <br>
+2023-07-14 | AES Quarg | updated <br>
+2023-07-14 | Mining Pinger | updated <br>
+2023-07-14 | Fighter Factory | updated <br>
+2023-07-14 | AES Irm | updated <br>
+2023-07-14 | AES Korath | updated <br>
+2023-07-14 | Mata | updated <br>
+2023-07-14 | SpaceCrate | updated <br>
+2023-07-14 | Midnight Expansion | updated <br>
+2023-07-14 | Low Tech Worlds | updated <br>
+2023-07-14 | Syndicate Story | updated <br>
+2023-07-14 | AES Aben | updated <br>
+2023-07-14 | sheragi-rebirth | updated <br>
+2023-07-13 | Endless-Endless-Sky | updated <br>
+2023-07-13 | Amphibious-Ships | updated <br>
+2023-07-12 | Lost in Midnight | updated <br>
+2023-07-11 | Amphibious-Ships | updated <br>
+2023-07-09 | Lost in Midnight | updated <br>
+2023-07-07 | Sounds Of Endless Sky | updated <br>
+2023-07-07 | Undisclosed Plugin | updated <br>
+2023-07-07 | Coalition-At-War | updated <br>
+2023-07-07 | Endless-Endless-Sky | updated <br>
+2023-07-07 | High DPI | updated <br>
+2023-07-07 | Portraits for News | updated <br>
+2023-07-07 | sensor | updated <br>
+2023-07-07 | Sci-Fi Flavours | updated <br>
+2023-07-07 | Arena of the worthy | updated <br>
+2023-07-07 | Midnight Scrapyard | updated <br>
+2023-07-07 | Beyond the Sky | updated <br>
+2023-07-07 | All Content Plugin | updated <br>
+2023-07-07 | Altera | updated <br>
+2023-07-07 | Outfit Highlighter | updated <br>
+2023-07-07 | additional.command.buttons | updated <br>
+2023-07-07 | Galactic War | updated <br>
+2023-07-07 | The Evora Navaiya | updated <br>
+2023-07-07 | Exporianes | updated <br>
+2023-07-07 | Shirni | updated <br>
+2023-07-07 | Play As Sestor | updated <br>
+2023-07-07 | Amphibious-Ships | updated <br>
+2023-07-07 | Blended Ships | updated <br>
+2023-07-07 | Lemurias Extra ES Stuff | updated <br>
+2023-07-07 | Mega Freight | updated <br>
+2023-07-07 | 40k Pack | updated <br>
+2023-07-07 | Space Shuttle Start | updated <br>
+2023-07-07 | Adamas Project | updated <br>
+2023-07-07 | World Forge | updated <br>
+2023-07-07 | Lost in Midnight | updated <br>
+2023-07-07 | Derogam | updated <br>
+2023-07-07 | Galaxias | updated <br>
+2023-06-28 | galactic.capital.investment | updated <br>
+2023-06-23 | galactic.capital.investment | updated <br>
+2023-06-22 | galactic.capital.investment | updated <br>
+2023-06-21 | too.many.asteroids | updated <br>
+2023-06-21 | additional.command.buttons | updated <br>
+2023-06-21 | snowfeather.robotics | updated <br>
+2023-06-20 | galactic.capital.investment | updated <br>
+2023-06-20 | automata.destruction.75percent | updated <br>
+2023-06-20 | automata.destruction.0percent | updated <br>
+2023-06-20 | kor.efret.shipyard | updated <br>
+2023-06-20 | unique.fix | updated <br>
+2023-06-20 | more.boarding.missions | updated <br>
+2023-06-20 | automata.destruction.51percent | updated <br>
+2023-06-20 | automata.in.human.space | updated <br>
+2023-06-20 | automata.destruction.23percent | updated <br>
+2023-06-19 | galactic.capital.investment | updated <br>
+2023-06-19 | automata.destruction.75percent | updated <br>
+2023-06-19 | automata.destruction.0percent | updated <br>
+2023-06-19 | kor.efret.shipyard | updated <br>
+2023-06-19 | unique.fix | updated <br>
+2023-06-19 | more.boarding.missions | updated <br>
+2023-06-19 | automata.destruction.51percent | updated <br>
+2023-06-19 | automata.in.human.space | updated <br>
+2023-06-19 | automata.destruction.23percent | updated <br>
+2023-06-17 | epo update: directlink and news | updated <br>

--- a/res/src/makemd.py
+++ b/res/src/makemd.py
@@ -1,10 +1,9 @@
 import os
 import requests
 from datetime import datetime
-import PIL
 from PIL import Image
 
-iconpng = assetfile = pluginname =  lastmodified = size = author = website = category = status = description = pluginnameurl = news = updatecheck =""
+iconpng = assetfile = pluginname =  lastmodified = size = author = website = category = status = description = pluginnameurl = news = allnews = updatecheck =""
 allplugins = cheats = gameplay = graphics = outfits = overhauls = overwrites = patches = races = ships = story = weapons = uncategorized = 0
 categories = ["Cheats", "Gameplay", "Graphics", "Outfits", "Overhauls", "Overwrites", "Patches", "Races", "Ships", "Story", "Weapons", "Uncategorized"]
 plist = []
@@ -27,6 +26,8 @@ with open("res/config.txt") as f:
 			pluginurl = line.split(" = ")[1]
 		if line.find("assetfullpath") == 0:	# i.e. assetfullpath = https://github.com/zuckung/test3/releases/download/Latest/
 			assetfullpath = line.split(" = ")[1]
+		if line.find("newsamount") == 0:	# i.e. newsamount = 20
+			newsamount = line.split(" = ")[1]
 			
 def replacevar(string): # replaces %variables% in header template with real values
 	if cat == "AllPlugins":
@@ -82,6 +83,7 @@ def replacevarp(string): # replaces %variables% in plugin and category template 
 	string = string.replace("%webroot%", webroot)
 	string = string.replace("%indexfile%", indexfile)
 	string = string.replace("%news%", news)
+	string = string.replace("%newsamount%", newsamount)	
 	string = string.replace("%updatecheck%", updatecheck)	
 	if website == "N/A": # for prevent [N/A](N/A) links
 		websitecheck = "N/A"
@@ -159,11 +161,33 @@ tempcatup = temptempcat[:pos] # upper half of template category
 tempcatdown = temptempcat[pos +12:] # lower half of template string
 
 
-with open("res/news.txt", "r") as file1: # reading and formating lines
+# writing res/allnews.md and putting the amount  of news entries defined in the config.txt to the new variable
+with open("res/news.txt", "r") as file1:
 	newslist = file1.readlines()
-for i in range(10): # define amount of news to 10
-	if i <= len(newslist)-1:
-		news = news + newslist[i] + "<br>"
+# get all values for all news
+for each in  newslist: 
+	news_line = each.split(" | ") # 3 variables from the news file
+	ndate = news_line[0]
+	nname = news_line[1]
+	nnew_or_update = news_line[2].split(" ")[0]
+	with open(listfolder + nname + ".txt", "r") as file1: # 2 valriables from the listfile
+		nauthor = file1.readline().replace("author=", "").strip()
+		ncat = file1.readline()
+		ncat = file1.readline()
+		ncat = file1.readline().replace("category=", "").strip()
+	if ncat == "N/A":
+		ncat = "uncategorized"
+	# got variables now: ndate, nnew_or_updated, nname, nauthor, ncat, define how a news line should look
+	nline = ndate + " | " +  nnew_or_update + " Plugin '" + nname + "' by " + nauthor + " | [" + ncat + "](" + webroot + indexfile + "#" + ncat + ")<br>\n"
+	allnews = allnews + nline
+with open("res/allnews.md", "w") as file1: # writing ALLNEWS.md
+	file1.writelines(allnews)
+split_str = "\n" # setting variable news to right format, to put into template
+splitted_news = allnews.split(split_str)
+part_news = splitted_news[:int(newsamount)]
+news = split_str.join(part_news)
+		
+
 
 # writing the md file
 with open("res/errorlog.txt", "w") as filerr: # resetting errorlog.txt

--- a/res/template.txt
+++ b/res/template.txt
@@ -2,7 +2,7 @@
 
 
 # News
-(latest 10 entries):
+(latest %newsamount% entries):
 <table><tr><td width=800>
 
 %news%
@@ -10,7 +10,7 @@
 </td></tr></table>
 Provide a directlink to your zipped plugin and we do a daily check if it is newer than the one we host here.<br>
 
-[howto](%webroot%%indexfile%#automatic-updating) | [view all news](%webroot%res/news.txt)
+[howto](%webroot%%indexfile%#automatic-updating) | [view all news](%webroot%res/allnews.md)
 
 ---
 
@@ -183,7 +183,7 @@ If you provide the `directlink=` in the plugin-file at `res/pluginlist/`, then t
 
 The files in `res/pluginlist/` which are used to generate this README.md, have a line `directlink=`, where you can put a URL to your zipped plugin. The line should look like: `directlink=https://github.com/userxyz/esplugins/releases/download/Latest/myplugin.zip` or any other directly accessible webspace.
 
-This repository does an automated check for your directlink once a day(03:30 am utc) and if your plugin there is newer than the one hosted here, it updates it and puts it in the news box. Please read naming convention paragraph to prevent errors.
+This repository does an automated check for your directlink once a day(23:30 am utc) and if your plugin there is newer than the one hosted here, it updates it and puts it in the news box. Please read naming convention paragraph to prevent errors.
 
 If you have a single plugin GitHub repo (with the data folder in root), you can use the auto-generated zip file (green button) as a direct update link. You can fork the official plugin template repository at [https://github.com/endless-sky/plugin-template](https://github.com/endless-sky/plugin-template).
 


### PR DESCRIPTION
-config.txt
  added newscount = 15 (amount of news in readme.md can be changed here)

-news.txt
  change to raw format:  'date | plugin_name | new_or_update <br>' (makemd.py generates the shown news with better formatting)

-makemd.py
  added amount of news entries, read from config.txt
  added allnews.md generation
  changed news reading format, to differentiate between new and updated plugins

-checkdirectlink.py
  changed news writing format, to differentiate between new and updated plugins

-template.txt
  added variable for amount of news entries in readme
  changed 'view all news' link to allndews.md
  changed update times to new values