### PR TITLE
Create a new plugin submission template

### DIFF
--- a/.github/ISSUE_TEMPLATE/plugin-submission.yaml
+++ b/.github/ISSUE_TEMPLATE/plugin-submission.yaml
@@ -1,0 +1,61 @@
+name: Plugin Submission
+description: Submit a new plugin to the archive
+assigness: Hecter94
+labels: New Submission
+title: New Plugin Submission
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for your interest in submitting a plugin to the archive.
+        Please check our [Plugin List](https://github.com/Hecter94/EndlessSky-PluginArchive/tree/issue-template/res/pluginlist) before submission to ensure it has not already been added before creating a new issue.
+
+        If the plugin is already in the archive and you want to rename or update it, please open a Pull Request.
+        If you have any questions regarding this form, please check our [ReadMe](https://github.com/Hecter94/EndlessSky-PluginArchive/blob/main/README.md#add-your-plugin)
+
+  - type: input
+    attributes:
+      label: Author
+      description: Enter the plugin Author; if yourself, enter how you want to be listed.
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Website
+      description: Please provide a valid website URL if the plugin is hosted online.
+    validations:
+      required: false
+  - type: input
+    attributes:
+      label: Direct Link
+      description: |
+      (Highly Recommended) Entering a direct link to the plugin's .zip file will enable automatic updating, allowing the archive to stay up-to-date with any changes.
+      If you do not provide a direct link, you must upload and attach the plugin to this issue. Be aware that GitHub has a 25MB maximum upload size.
+    validations:
+      required: false
+  - type: dropdown
+    attributes:
+      label: Category
+      description: Please select a category for the plugin to be listed as.
+      options:
+        - Cheats
+        - Gameplay
+        - Graphics
+        - Outfits
+        - Overhauls
+        - Patches
+        - Races
+        - Ships
+        - Story
+        - Weapons
+        - Uncategorized
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Status
+      description: Please enter the current status of the plugin, whether it is complete, in progress, abandoned, etc.
+  - type: textarea
+    attributes:
+      label: Description
+      description: Please include a short description of the plugin.

--- a/.github/ISSUE_TEMPLATE/plugin-submission.yaml
+++ b/.github/ISSUE_TEMPLATE/plugin-submission.yaml
@@ -29,8 +29,8 @@ body:
     attributes:
       label: Direct Link
       description: |
-      (Highly Recommended) Entering a direct link to the plugin's .zip file will enable automatic updating, allowing the archive to stay up-to-date with any changes.
-      If you do not provide a direct link, you must upload and attach the plugin to this issue. Be aware that GitHub has a 25MB maximum upload size.
+        (Highly Recommended) Entering a direct link to the plugin's .zip file will enable automatic updating, allowing the archive to stay up-to-date with any changes.
+        If you do not provide a direct link, you must upload and attach the plugin to this issue. Be aware that GitHub has a 25MB maximum upload size.
     validations:
       required: false
   - type: dropdown
@@ -55,11 +55,11 @@ body:
     attributes:
       label: Status
       description: Please enter the current status of the plugin, whether it is complete, in progress, abandoned, etc.
-      validations:
-        required: true
+    validations:
+      required: true
   - type: input
     attributes:
       label: Description
       description: Please include a short description of the plugin.
-      validations:
-        required: true
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/plugin-submission.yaml
+++ b/.github/ISSUE_TEMPLATE/plugin-submission.yaml
@@ -63,7 +63,3 @@ body:
       description: Please include a short description of the plugin.
       validations:
         required: true
-  - type: textarea
-    attributes:
-      label: Long Description
-      description: If you would like to include a longer description of the plugin, do so here.

--- a/.github/ISSUE_TEMPLATE/plugin-submission.yaml
+++ b/.github/ISSUE_TEMPLATE/plugin-submission.yaml
@@ -55,7 +55,15 @@ body:
     attributes:
       label: Status
       description: Please enter the current status of the plugin, whether it is complete, in progress, abandoned, etc.
-  - type: textarea
+      validations:
+        required: true
+  - type: input
     attributes:
       label: Description
       description: Please include a short description of the plugin.
+      validations:
+        required: true
+  - type: textarea
+    attributes:
+      label: Long Description
+      description: If you would like to include a longer description of the plugin, do so here.

--- a/.github/ISSUE_TEMPLATE/plugin-submission.yaml
+++ b/.github/ISSUE_TEMPLATE/plugin-submission.yaml
@@ -15,6 +15,12 @@ body:
 
   - type: input
     attributes:
+      label: Name
+      description: Enter the name of the plugin.
+    validations:
+      required: true
+  - type: input
+    attributes:
       label: Author
       description: Enter the plugin Author; if yourself, enter how you want to be listed.
     validations:


### PR DESCRIPTION
This allows anyone to easily submit a request to add a new plugin to the archive without requiring a PR. 
The template asks for the following information:
author
website
directlink
category
status
description
long description

When submitted, the issue will automatically be tagged and assigned, allowing manual addition of the plugin to the archive, at which point the issue can be completed.