### PR TITLE
workaround for 512kb README.md render limit

### DIFF
--- a/.github/workflows/automatic_check_updates.yml
+++ b/.github/workflows/automatic_check_updates.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           git config user.name "script" 
           git config user.email "<>"
-          git add 'README.md' 'res/allnews.md'
+          git add 'README.md' 'plugins.md' 'res/allnews.md'
           git commit -m "Plugin md generated" || true
       - name: Push changes
         uses: ad-m/github-push-action@master

--- a/.github/workflows/manual_make_readme.yml
+++ b/.github/workflows/manual_make_readme.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
 jobs:
   First:
-    name: First job
+    name: make readme
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
@@ -21,7 +21,7 @@ jobs:
         run: |
           git config user.name "script" 
           git config user.email "<>"
-          git add .
+          git add 'README.md' 'plugins.md' 'res/allnews.md'
           git commit -m "Plugin md generated" || true
       - name: Push changes
         uses: ad-m/github-push-action@master

--- a/res/src/makemd.py
+++ b/res/src/makemd.py
@@ -198,7 +198,7 @@ for each in  newslist:
 		if ncat == "N/A":
 			ncat = "uncategorized"
 		# got variables now: ndate, nnew_or_updated, nname, nauthor, ncat, define how a news line should look
-		nline = ndate + " | " +  nnew_or_update + " Plugin '" + nname + "' by " + nauthor + " | [" + ncat + "](" + webroot + indexfile + "#" + ncat + ")<br>\n"
+		nline = ndate + " | " +  nnew_or_update + " Plugin '" + nname + "' by " + nauthor + " | [" + ncat + "](" + webroot + "plugins.md#" + ncat + ")<br>\n"
 	else: # no listfile found, plugin must got deleted or renamed
 		nline = ndate + " | " + nnew_or_update + " Plugin " + nname + " | Plugin got deleted or renamed <br>\n"
 	allnews = allnews + nline
@@ -216,6 +216,7 @@ with open(indexfile, "w") as file1:
 	temphead = replacevar(temphead)
 	temphead = replacevarp(temphead)
 	file1.writelines(temphead) # writer header template
+with open("plugins.md", "w") as file1:
 	for cat in categories: # for each category
 		tempcatupt = tempcatup.replace("%category%", cat)
 		tempcatupt = replacevar(tempcatupt)

--- a/res/template.txt
+++ b/res/template.txt
@@ -30,18 +30,18 @@ Provide a direct link to your zipped plugin to enable automatic updating.<br>
 - [Plugin Naming Convention](%webroot%%indexfile%#plugin-naming-convention)
 
 [Plugin Download](%webroot%%indexfile%#plugin-download)
-- [Cheats](%webroot%%indexfile%#cheats)
-- [Gameplay](%webroot%%indexfile%#gameplay)
-- [Graphics](%webroot%%indexfile%#graphics)
-- [Outfits](%webroot%%indexfile%#outfits)
-- [Overhauls](%webroot%%indexfile%#overhauls)
-- [Overwrites](%webroot%%indexfile%#overwrites)
-- [Patches](%webroot%%indexfile%#patches)
-- [Races](%webroot%%indexfile%#races)
-- [Ships](%webroot%%indexfile%#ships)
-- [Story](%webroot%%indexfile%#story)
-- [Weapons](%webroot%%indexfile%#weapons)
-- [Uncategorized](%webroot%%indexfile%#uncategorized)
+- [Cheats](%webroot%plugins.md#cheats)
+- [Gameplay](%webroot%plugins.md#gameplay)
+- [Graphics](%webroot%plugins.md#graphics)
+- [Outfits](%webroot%plugins.md#outfits)
+- [Overhauls](%webroot%plugins.md#overhauls)
+- [Overwrites](%webroot%plugins.md#overwrites)
+- [Patches](%webroot%plugins.md#patches)
+- [Races](%webroot%plugins.md#races)
+- [Ships](%webroot%plugins.md#ships)
+- [Story](%webroot%plugins.md#story)
+- [Weapons](%webroot%plugins.md#weapons)
+- [Uncategorized](%webroot%plugins.md#uncategorized)
 
 ---
 
@@ -53,13 +53,13 @@ A comprehensive library of %allplugins% ancient and new plugins for the open-sou
 
 # Download Information
 
-All plugins can be downloaded directly [here](https://github.com/Hecter94/EndlessSky-PluginArchive#plugin-download) or as zip files from the [releases](https://github.com/Hecter94/EndlessSky-PluginArchive/releases/tag/Latest) page.
+All plugins can be downloaded directly [here](%webroot%plugins.md) or as zip files from the [releases](%webroot%releases/tag/Latest) page.
 
 ## Downloading Alternative
 
 Third-party tools such as [https://download-directory.github.io](https://download-directory.github.io/) can download a single folder/plugin. Paste the folder URL into that tool and you will be given a .zip file for that folder.
 
-For example, for the "50 cal" plugin, enter: [https://github.com/Hecter94/EndlessSky-PluginArchive/tree/main/Working/50%20cal](https://github.com/Hecter94/EndlessSky-PluginArchive/tree/main/Working/50%20cal)
+For example, for the "50 cal" plugin, enter: [%webroot%Working/50%20cal](%webroot%Working/50%20cal)
 
 Github, by default, only allows the entire library to be downloaded as a single .zip. GitHub may have issues downloading large file sizes; a possible workaround is using GitHub Desktop or Git Bash to clone the repository.
 
@@ -123,9 +123,9 @@ To keep these files related, you must give them the same name.
 
 All Plugins (%allplugins%)
 
-[Cheats](%webroot%%indexfile%#cheats) (%cheats%) | [Gameplay](%webroot%%indexfile%#gameplay) (%gameplay%) | [Graphics](%webroot%%indexfile%#graphics) (%graphics%) | [Outfits](%webroot%%indexfile%#outfits) (%outfits%)<br>
-[Overhauls](%webroot%%indexfile%#overhauls) (%overhauls%) | [Overwrites](%webroot%%indexfile%#overwrites) (%overwrites%) | [Patches](%webroot%%indexfile%#patches) (%patches%) | [Races](%webroot%%indexfile%#races) (%races%)<br>
-[Ships](%webroot%%indexfile%#ships) (%ships%) | [Story](%webroot%%indexfile%#story) (%story%) | [Weapons](%webroot%%indexfile%#weapons) (%weapons%) | [Uncategorized](%webroot%%indexfile%#uncategorized) (%uncategorized%)<br>
+[Cheats](%webroot%plugins.md#cheats) (%cheats%) | [Gameplay](%webroot%plugins.md#gameplay) (%gameplay%) | [Graphics](%webroot%plugins.md#graphics) (%graphics%) | [Outfits](%webroot%plugins.md#outfits) (%outfits%)<br>
+[Overhauls](%webroot%plugins.md#overhauls) (%overhauls%) | [Overwrites](%webroot%plugins.md#overwrites) (%overwrites%) | [Patches](%webroot%plugins.md#patches) (%patches%) | [Races](%webroot%plugins.md#races) (%races%)<br>
+[Ships](%webroot%plugins.md#ships) (%ships%) | [Story](%webroot%plugins.md#story) (%story%) | [Weapons](%webroot%plugins.md#weapons) (%weapons%) | [Uncategorized](%webroot%plugins.md#uncategorized) (%uncategorized%)<br>
 
 
 %%% template for category below this point %%%
@@ -143,7 +143,7 @@ All Plugins (%allplugins%)
 </details>
 
 
-[back to top](%webroot%%indexfile%#%category%)
+[back to top](%webroot%plugins.md#%category%)
 
 
 %%% template for plugin entry below this point %%%


### PR DESCRIPTION
Unfortunately the plugin readmes let the README.md grow from 300kb to 550kb, which exceeded an start page readme render limit of 512kb.

makemd.py
changed writing of README.md (header goes to README.md, categories and plugins to plugins.md)
changed news generated category anchor links to plugins.md

automatic_check_updates.yml & manual_make_readme.yml
added plugins.md to push paths

template.txt
changed all category anchor links to plugins.md