### PR TITLE
added workflow failing on non critical errors

### DIFF
--- a/.github/workflows/automatic_check_updates.yml
+++ b/.github/workflows/automatic_check_updates.yml
@@ -55,3 +55,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           force: true
+      - name: Check directlinks for updates
+        run: python res/src/failworkflow.py

--- a/.github/workflows/automatic_check_updates.yml
+++ b/.github/workflows/automatic_check_updates.yml
@@ -55,5 +55,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           force: true
-      - name: Check directlinks for updates
+      - name: Check for errors
         run: python res/src/failworkflow.py

--- a/res/src/checkdirectlinks.py
+++ b/res/src/checkdirectlinks.py
@@ -27,8 +27,8 @@ with open("res/config.txt") as f:
 
 # creating temp directory			
 if os.path.isdir("temp") == False: 
-	os.mkdir("temp")			
-	
+	os.mkdir("temp")
+
 # creating res/last_commits.txt
 with open("res/last_commits.txt", "w") as file1:
 	file1.write("")
@@ -97,6 +97,8 @@ for entry in entries:
 			response = requests.head(directlink, allow_redirects=True)
 			response.raise_for_status()
 		except requests.exceptions.HTTPError as err:
+			with open('res/errorlog.txt', 'a') as errorfile:
+				errorfile.writelines("check directlink for plugin: " + pluginname + " | " + directlink + "\n")
 			print("ERROR: directlink not reachable: " + directlink)
 			print(err)
 			continue
@@ -118,6 +120,8 @@ for entry in entries:
 						params = {'page': '1', 'per_page': '1'}
 						response = requests.get('https://api.github.com/repos/' + author +'/' + plug + '/commits', params=params, auth=(username,token))
 					except:
+						with open('res/errorlog.txt', 'a') as errorfile:
+							errorfile.writelines("check github website for plugin: " + pluginname + " | not reachable, can't read last commit\n")
 						print("ERROR: github api not reachable: " + plug)
 						linklastmodified = "FALSE"
 						continue
@@ -131,6 +135,8 @@ for entry in entries:
 		if linksize != "FALSE":
 			if linksize >= 307200:
 				print("ABORTING: directlink is bigger than 300 mb")
+				with open('res/errorlog.txt', 'a') as errorfile:
+					errorfile.writelines("file size for plugin: " + pluginname + " is bigger than 300mb, needs to be rised\n")
 				continue
 				
 		if linklastmodified != "FALSE":

--- a/res/src/failworkflow.py
+++ b/res/src/failworkflow.py
@@ -1,0 +1,10 @@
+import os
+if os.path.isfile('res/errorlog.txt'):
+	with open('res/errorlog.txt') as file1:
+		content = file1.read()
+	print('The following non-critical errors were found:\n')
+	print(content)
+	print('\nFailing workflow on purpose now!')
+	fail_command
+else:
+	print("The scripts didn't generate errors.")

--- a/res/src/makemd.py
+++ b/res/src/makemd.py
@@ -276,6 +276,8 @@ with open("plugins.md", "w") as file1:
 					response = requests.head(assetfullpath + withdots + ".zip", allow_redirects=True) # get header of the release asset zips
 					response.raise_for_status()
 				except requests.exceptions.HTTPError as err:
+					with open('res/errorlog.txt', 'a') as errorfile:
+						errorfile.writelines("check release zip for plugin: " + pluginname + "\n")
 					print(err)
 					lastmodified = "N/A"
 					size = "N/A" 


### PR DESCRIPTION
added saving of non critical errors to checkdirectlinks.py and makemd.py. A third new script 'failworkflow.py' reads these errors and fails the workflow if there are any.  All things done before the failing get pushed to the repository, i.e. plugins get updated or readme gets creates. The failing is just optical.

checkdirectlinks.py can generate 3 errors:
<ul><li>
`check directlink for plugin: pluginname | directlink`
 ... Means dead directlink, or temporarily dead directlink. if github page got deleted, the website= and directlink= in the pluginlist file needs to get set to 'N/A'.</li>
<li>
`check github website for plugin: pluginname | not reachable, can't read last commit`
... Some plugins have a github website but no directlink, cause of incorrect folder structure. these github pages get read by the api for the last commit date. the error means, website is dead or temporarily dead. check it and correct plugin list file.</li>
<li>
`file size for plugin: pluginname is bigger than 300mb, needs to be rised`
... Should nearly never appear, because in most cases the script can't read the filesize. If it appears, checkdirectlinks.py line 136 containes the allowed filesize.</li></ul>

makemd.py can generate 1 error:
<ul><li>
`check release zip for plugin: " + pluginname`
... The readme checks for every data folder if the release zip is there. In this case it can't be reached. Maybe renamed? Deleted? Needs further checks for release zip and/or working/pluginfolder. Manual make assets workflow creates the zip out of a working/pluginfolder.</li></ul>