### PR TITLE
updating link to poiint to new url after repo transfer

### DIFF
--- a/res/pluginlist/Cognitive Subdivision.txt
+++ b/res/pluginlist/Cognitive Subdivision.txt
@@ -1,6 +1,6 @@
-author=myvee
-website=https://github.com/myvee/cognitive-subdivision
-directlink=https://github.com/myvee/cognitive-subdivision/archive/refs/heads/master.zip
+author=Maryn-s
+website=https://github.com/Maryn-s/cognitive-subdivision
+directlink=https://github.com/Maryn-s/cognitive-subdivision/archive/refs/heads/master.zip
 category=story
 status=N/A
 description=Cognitive Subdivision introduces a new difficult story taking place after the first part of the Wanderer Campaign


### PR DESCRIPTION
I've transfered my repos from my other account to my original account since I want to use this account to focus more on ES stuff. So the link has been updated to reflect that change and avoid any issues.