### PR TITLE
plugin.md fix

### DIFF
--- a/.github/workflows/automatic_check_updates.yml
+++ b/.github/workflows/automatic_check_updates.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           git config user.name "script" 
           git config user.email "<>"
-          git add 'README.md' 'plugins.md' 'res/allnews.md'
+          git add 'README.md' 'res/'
           git commit -m "Plugin md generated" || true
       - name: Push changes
         uses: ad-m/github-push-action@master

--- a/.github/workflows/manual_check_updates_readme.yml
+++ b/.github/workflows/manual_check_updates_readme.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           git config user.name "script" 
           git config user.email "<>"
-          git add 'README.md' 'res/allnews.md'
+          git add 'README.md' 'res/'
           git commit -m "Plugin md generated" || true
       - name: Push changes
         uses: ad-m/github-push-action@master

--- a/.github/workflows/manual_make_readme.yml
+++ b/.github/workflows/manual_make_readme.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           git config user.name "script" 
           git config user.email "<>"
-          git add 'README.md' 'plugins.md' 'res/allnews.md'
+          git add 'README.md' 'res/'
           git commit -m "Plugin md generated" || true
       - name: Push changes
         uses: ad-m/github-push-action@master

--- a/res/src/makemd.py
+++ b/res/src/makemd.py
@@ -202,7 +202,7 @@ for each in  newslist:
 		if ncat == "N/A":
 			ncat = "uncategorized"
 		# got variables now: ndate, nnew_or_updated, nname, nauthor, ncat, define how a news line should look
-		nline = ndate + " | " +  nnew_or_update + " Plugin '" + nname + "' by " + nauthor + " | [" + ncat + "](" + webroot + "plugins.md#" + ncat + ")<br>\n"
+		nline = ndate + " | " +  nnew_or_update + " Plugin '" + nname + "' by " + nauthor + " | [" + ncat.lower() + "](" + webroot + 'res/mds/' + ncat.lower() + ".md)<br>\n"
 	else: # no listfile found, plugin must got deleted or renamed
 		nline = ndate + " | " + nnew_or_update + " Plugin " + nname + " | Plugin got deleted or renamed <br>\n"
 	allnews = allnews + nline
@@ -215,13 +215,15 @@ news = split_str.join(part_news)
 		
 
 
-# writing the md file
+# writing the md files
 with open(indexfile, "w") as file1:
 	temphead = replacevar(temphead)
 	temphead = replacevarp(temphead)
 	file1.writelines(temphead) # writer header template
-with open("plugins.md", "w") as file1:
-	for cat in categories: # for each category
+	if not os.path.isdir('res/mds/'):
+		os.mkdir('res/mds/')
+for cat in categories: # for each category
+	with open('res/mds/' + cat.lower() + ".md", "w") as file1:
 		tempcatupt = tempcatup.replace("%category%", cat)
 		tempcatupt = replacevar(tempcatupt)
 		tempcatupt = replacevarp(tempcatupt)
@@ -262,7 +264,7 @@ with open("plugins.md", "w") as file1:
 					iconpath = iconpath.replace("(", "%28")
 					iconpath = iconpath.replace(")", "%29")
 					iconpath = iconpath.replace(",", "%2C")
-					iconpng = "<img src='"+ iconpath + "/icon.png' height='100'></img><br>\n"
+					iconpng = "<img src='../../"+ iconpath + "/icon.png' height='100'></img><br>\n"
 				else:
 					iconpng = ""
 				# get last modified date and size from the assetfiles
@@ -296,9 +298,9 @@ with open("plugins.md", "w") as file1:
 						form = " mb"
 					size = str(round(assetsize, 2)) + form
 					if directlink != "N/A": # check if plugin has direct updating and insert png
-						updatecheck = "<img src='res/img/check.png' width='15' ></img>"
+						updatecheck = "<img src='../img/check.png' width='15' ></img>"
 					else:
-						updatecheck = "<img src='res/img/cross.png' width='15' ></img>"
+						updatecheck = "<img src='../img/cross.png' width='15' ></img>"
 				assetfile =  withdots + ".zip"
 				
 				# get last commit from the plugin repo

--- a/res/template.txt
+++ b/res/template.txt
@@ -30,18 +30,18 @@ Provide a direct link to your zipped plugin to enable automatic updating.<br>
 - [Plugin Naming Convention](%webroot%%indexfile%#plugin-naming-convention)
 
 [Plugin Download](%webroot%%indexfile%#plugin-download)
-- [Cheats](%webroot%plugins.md#cheats)
-- [Gameplay](%webroot%plugins.md#gameplay)
-- [Graphics](%webroot%plugins.md#graphics)
-- [Outfits](%webroot%plugins.md#outfits)
-- [Overhauls](%webroot%plugins.md#overhauls)
-- [Overwrites](%webroot%plugins.md#overwrites)
-- [Patches](%webroot%plugins.md#patches)
-- [Races](%webroot%plugins.md#races)
-- [Ships](%webroot%plugins.md#ships)
-- [Story](%webroot%plugins.md#story)
-- [Weapons](%webroot%plugins.md#weapons)
-- [Uncategorized](%webroot%plugins.md#uncategorized)
+- [Cheats](%webroot%res/mds/cheats.md)
+- [Gameplay](%webroot%res/mds/gameplay.md)
+- [Graphics](%webroot%res/mds/graphics.md)
+- [Outfits](%webroot%res/mds/outfits.md)
+- [Overhauls](%webroot%res/mds/overhauls.md)
+- [Overwrites](%webroot%res/mds/overwrites.md)
+- [Patches](%webroot%res/mds/patches.md)
+- [Races](%webroot%res/mds/races.md)
+- [Ships](%webroot%res/mds/ships.md)
+- [Story](%webroot%res/mds/story.md)
+- [Weapons](%webroot%res/mds/weapons.md)
+- [Uncategorized](%webroot%res/mds/uncategorized.md)
 
 ---
 
@@ -123,9 +123,10 @@ To keep these files related, you must give them the same name.
 
 All Plugins (%allplugins%)
 
-[Cheats](%webroot%plugins.md#cheats) (%cheats%) | [Gameplay](%webroot%plugins.md#gameplay) (%gameplay%) | [Graphics](%webroot%plugins.md#graphics) (%graphics%) | [Outfits](%webroot%plugins.md#outfits) (%outfits%)<br>
-[Overhauls](%webroot%plugins.md#overhauls) (%overhauls%) | [Overwrites](%webroot%plugins.md#overwrites) (%overwrites%) | [Patches](%webroot%plugins.md#patches) (%patches%) | [Races](%webroot%plugins.md#races) (%races%)<br>
-[Ships](%webroot%plugins.md#ships) (%ships%) | [Story](%webroot%plugins.md#story) (%story%) | [Weapons](%webroot%plugins.md#weapons) (%weapons%) | [Uncategorized](%webroot%plugins.md#uncategorized) (%uncategorized%)<br>
+[Cheats](%webroot%res/mds/cheats.md) (%cheats%) | [Gameplay](%webroot%res/mds/gameplay.md) (%gameplay%) | [Graphics](%webroot%res/mds/graphics.md) (%graphics%) | [Outfits](%webroot%res/mds/outfits.md) (%outfits%)<br>
+[Overhauls](%webroot%res/mds/overhauls.md) (%overhauls%) | [Overwrites](%webroot%res/mds/overwrites.md) (%overwrites%) | [Patches](%webroot%res/mds/patches.md) (%patches%) | [Races](%webroot%res/mds/races.md) (%races%)<br>
+[Ships](%webroot%res/mds/ships.md) (%ships%) | [Story](%webroot%res/mds/story.md) (%story%) | [Weapons](%webroot%res/mds/weapons.md) (%weapons%) | [Uncategorized](%webroot%res/mds/uncategorized.md) (%uncategorized%)<br>
+
 
 
 %%% template for category below this point %%%
@@ -136,14 +137,9 @@ All Plugins (%allplugins%)
 
 <p>%amount% plugins in this category.<p>
 
-<details>
 
  %pluginhere%
 
-</details>
-
-
-[back to top](%webroot%plugins.md#%category%)
 
 
 %%% template for plugin entry below this point %%%


### PR DESCRIPTION
splits the plugin.md to an own md for each category (in res/mds/)
adjusted all 3 workflows which create the mds
adjusted the template to give correct links

the workflow errors should be fixed with this, and all categories can be seen again.