### PR TITLE
several script fixes

### DIFF
--- a/.github/workflows/automatic_check_updates.yml
+++ b/.github/workflows/automatic_check_updates.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Install beautifulsoup4 and Pillow
@@ -34,7 +34,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           force: true
       - name: Upload plugins to release
-        uses: ncipollo/release-action@v1.11.1
+        uses: ncipollo/release-actionv@1.14.0
         with:
           name: Downloads
           tag: Latest

--- a/.github/workflows/manual_check_updates.yml
+++ b/.github/workflows/manual_check_updates.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Install beautifulsoup4 and Pillow
@@ -31,7 +31,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           force: true
       - name: Upload plugins to release
-        uses: ncipollo/release-action@v1.11.1
+        uses: ncipollo/release-action@v1.14.0
         with:
           name: Downloads
           tag: Latest

--- a/.github/workflows/manual_check_updates_readme.yml
+++ b/.github/workflows/manual_check_updates_readme.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Install beautifulsoup4 and Pillow
         run: |
-          python3 -m pip install bs4 --break-system-packages
-          python3 -m pip install lxml --break-system-packages
-          python3 -m pip install Pillow --break-system-packages
+          python3 -m pip install bs4
+          python3 -m pip install lxml
+          python3 -m pip install Pillow
       - name: Check directlinks for updates
         run: python res/src/checkdirectlinks.py
       - name: Commit file
@@ -31,7 +31,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           force: true
       - name: Upload plugins to release
-        uses: ncipollo/release-action@v1.11.1
+        uses: ncipollo/release-action@v1.14.0
         with:
           name: Downloads
           tag: Latest

--- a/.github/workflows/manual_create_assets.yml
+++ b/.github/workflows/manual_create_assets.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: makeassets
         run: python res/src/makeassets.py
       - name: Upload plugins to release
-        uses: ncipollo/release-action@v1.12.0
+        uses: ncipollo/release-action@v1.14.0
         with:
           name: Downloads
           tag: Latest

--- a/.github/workflows/manual_make_readme.yml
+++ b/.github/workflows/manual_make_readme.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Install beautifulsoup4 and Pillow

--- a/.github/workflows/on_issue.yml
+++ b/.github/workflows/on_issue.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Create txt file out of issue body
         run: |
           ISSUE_INPUT="${{ github.event.issue.body }}" python3 res/src/onissue.py
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7
         with:
           commit-message: added a plugin txt
           title: New plugin added

--- a/.github/workflows/on_push_in_working_dir .yml
+++ b/.github/workflows/on_push_in_working_dir .yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Analyse changed plugins
         id: files
-        uses: tj-actions/changed-files@v28.0.0
+        uses: tj-actions/changed-files@v45.0.3
         with:
           separator: '%%%'
       - name: Zip changed plugins
@@ -34,26 +34,27 @@ jobs:
             print("The following plugins have changed:")
             for p in plugins:
               print(p)
-              os.chdir('Working')
-              corrected = p.replace(" ", ".")
-              corrected = corrected.replace("'", ".") 
-              corrected = corrected.replace(",", ".") 
-              corrected = corrected.replace("(", ".") 
-              corrected = corrected.replace(")", ".") 
-              corrected = corrected.replace("&", ".") 
-              corrected = corrected.replace(",", ".") 
-              corrected = corrected.replace("...", ".")
-              corrected = corrected.replace("..", ".") 
-              if corrected[len(corrected)-1] == ".":
-                corrected = corrected[:len(corrected)-1]
-              subprocess.run(["zip", "-r", "../" + corrected + ".zip", p],
-                stdout=subprocess.DEVNULL)
-              os.chdir('../')
+              if os.path.isdir('Working/' + p):
+                os.chdir('Working')
+                corrected = p.replace(" ", ".")
+                corrected = corrected.replace("'", ".")
+                corrected = corrected.replace(",", ".")
+                corrected = corrected.replace("(", ".")
+                corrected = corrected.replace(")", ".")
+                corrected = corrected.replace("&", ".")
+                corrected = corrected.replace(",", ".")
+                corrected = corrected.replace("...", ".")
+                corrected = corrected.replace("..", ".")
+                if corrected[len(corrected)-1] == ".":
+                  corrected = corrected[:len(corrected)-1]
+                subprocess.run(["zip", "-r", "../" + corrected + ".zip", p],
+                  stdout=subprocess.DEVNULL)
+                os.chdir('../')
           else:
             print("No plugin changes have been detected.")
         shell: python
       - name: Upload plugins to release
-        uses: ncipollo/release-action@v1.11.1
+        uses: ncipollo/release-action@v1.14.0
         with:
           name: Downloads
           tag: Latest

--- a/res/src/makemd.py
+++ b/res/src/makemd.py
@@ -103,7 +103,7 @@ def replacevarp(string): # replaces %variables% in plugin and category template 
 	string = string.replace("%updatecheck%", updatecheck)
 	string = string.replace("%readme%", readme)
 	string = string.replace("%last_commit%", repo_last_commit)
-	if website == "N/A": # for prevent [N/A](N/A) links
+	if website == "N/A" or website == "" or website == "NA": # for prevent [N/A](N/A) links
 		websitecheck = "N/A"
 		websitelink = ""
 	else:
@@ -112,6 +112,7 @@ def replacevarp(string): # replaces %variables% in plugin and category template 
 	string = string.replace("%website%", websitelink)
 	string = string.replace("%websitecheck%", websitecheck)
 	string = string.replace("%category%", category)
+	string = string.replace("%lowercategory%", category.lower())
 	string = string.replace("%status%", status)
 	string = string.replace("%iconpng%", str(iconpng))
 	string = string.replace("%pluginnameurl%", pluginnameurl)	
@@ -135,27 +136,27 @@ for entry in entries:
 			cat = file1.readline()
 			cat = file1.readline()
 			cat = file1.readline().split("=")[1].replace("\n", "")
-			if cat == "cheats": # count plugins in category
+			if cat.lower() == "cheats": # count plugins in category
 				cheats += 1
-			elif cat == "gameplay":
+			elif cat.lower() == "gameplay":
 				gameplay += 1
-			elif cat == "graphics":
+			elif cat.lower() == "graphics":
 				graphics += 1
-			elif cat == "outfits":
+			elif cat.lower() == "outfits":
 				outfits += 1
-			elif cat == "overhauls":
+			elif cat.lower() == "overhauls":
 				overhauls += 1
-			elif cat == "overwrites":
+			elif cat.lower() == "overwrites":
 				overwrites += 1
-			elif cat == "patches":
+			elif cat.lower() == "patches":
 				patches += 1
-			elif cat == "races":
+			elif cat.lower() == "races":
 				races += 1
-			elif cat == "ships":
+			elif cat.lower() == "ships":
 				ships += 1
-			elif cat == "story":
+			elif cat.lower() == "story":
 				story += 1
-			elif cat == "weapons":
+			elif cat.lower() == "weapons":
 				weapons += 1
 			else:
 				uncategorized += 1
@@ -199,10 +200,10 @@ for each in  newslist:
 			ncat = file1.readline()
 			ncat = file1.readline()
 			ncat = file1.readline().replace("category=", "").strip()
-		if ncat == "N/A":
+		if ncat == "N/A" or ncat == "" or ncat == "NA":
 			ncat = "uncategorized"
 		# got variables now: ndate, nnew_or_updated, nname, nauthor, ncat, define how a news line should look
-		nline = ndate + " | " +  nnew_or_update + " Plugin '" + nname + "' by " + nauthor + " | [" + ncat.lower() + "](" + webroot + 'res/mds/' + ncat.lower() + ".md)<br>\n"
+		nline = ndate + " | " +  nnew_or_update + " Plugin '" + nname + "' by " + nauthor + " | [" + ncat.lower() + "](" + webroot + 'res/mds/' + ncat.lower() + ".md#" + nname.lower().replace(' ', '-').replace('.', '') + ")<br>\n"
 	else: # no listfile found, plugin must got deleted or renamed
 		nline = ndate + " | " + nnew_or_update + " Plugin " + nname + " | Plugin got deleted or renamed <br>\n"
 	allnews = allnews + nline
@@ -235,12 +236,12 @@ for cat in categories: # for each category
 			pos = p.find("\n")
 			catcomp = p[:pos]
 			catcomp = catcomp.strip() # get category for comparing with actual category
-			if catcomp == "N/A":
+			if catcomp == "N/A" or catcomp == "" or catcomp == "NA":
 				catcomp = "Uncategorized"
 			if catcomp.capitalize() == cat:
 				# get variables out of the list item p
 				description = p.split("\n")
-				if description[0] == "N/A":
+				if description[0] == "N/A" or description == "" or description == "NA":
 					category = description[0]
 				else:
 					category = description[0].capitalize() 
@@ -320,6 +321,7 @@ for cat in categories: # for each category
 					if each.lower().find("readme") != -1:
 						with open(pathtoplugins + pluginname + "/" + each) as readmefile:
 							readme = "<details>\n<summary>:blue_book: Plugin readme</summary>\n<blockquote>" + readmefile.read() + "\n</blockquote>\n</details>"
+							readme = readme.replace('~', '')
 					
 				file1.writelines(replacevarp(tempplug)) # write plugin template entry, exchanging %variables%
 		file1.writelines(tempcatdownt) # write lower category template

--- a/res/template.txt
+++ b/res/template.txt
@@ -131,6 +131,12 @@ All Plugins (%allplugins%)
 
 %%% template for category below this point %%%
 
+All Plugins (%allplugins%)
+
+[Cheats](%webroot%res/mds/cheats.md) (%cheats%) | [Gameplay](%webroot%res/mds/gameplay.md) (%gameplay%) | [Graphics](%webroot%res/mds/graphics.md) (%graphics%) | [Outfits](%webroot%res/mds/outfits.md) (%outfits%)<br>
+[Overhauls](%webroot%res/mds/overhauls.md) (%overhauls%) | [Overwrites](%webroot%res/mds/overwrites.md) (%overwrites%) | [Patches](%webroot%res/mds/patches.md) (%patches%) | [Races](%webroot%res/mds/races.md) (%races%)<br>
+[Ships](%webroot%res/mds/ships.md) (%ships%) | [Story](%webroot%res/mds/story.md) (%story%) | [Weapons](%webroot%res/mds/weapons.md) (%weapons%) | [Uncategorized](%webroot%res/mds/uncategorized.md) (%uncategorized%)<br>
+
 ---
 
 ## %category%
@@ -140,6 +146,8 @@ All Plugins (%allplugins%)
 
  %pluginhere%
 
+
+[back to top](%webroot%res/mds/%lowercategory%.md#%lowercategory%)
 
 
 %%% template for plugin entry below this point %%%


### PR DESCRIPTION
can't reproduce '""' issue, close #170, maybe fixed with new pull request action version

.github/workflows/
   all workflows > actions/checkout@v3 > actions/checkout@v4
   all workflows > ncipollo/release-action@v1.11.1 > ncipollo/release-action@v1.14.1release-action@v1.14.0

.github/workflows/on_issue.yml
  peter-evans/create-pull-request@v5 > peter-evans/create-pull-request@v7

.github/workflows/on_push_in_working_dir.yml
  fixed workflow failing when deleting a plugin folder

.github/workflows/manual_check_updates_readme.yml
  fixed --break-system-packages

.github/workflows/on_push_in_working_dir.yml
  tj-actions/changed-files@28.0.0 > tj-actions/changed-files@v45.0.3

res/src/checkdirectlinks.py
  plugin size check removed, doesnt seem to work, i coded too chaotic
  "N/A" "NA" and nothing is now possible in pluginfiles (issue fix #173)
  added 2nd asset link check if first fails (to prevent marking plugin updates as new plugin)

res/src/makemd.py
  "N/A" "NA" and nothing is now possible in pluginfiles
  fixed "~" in plugin readmes messing up the plugin lists (like in core mining, which got an update recently messing up races category)
  fixed category plugin counting bug when category in pluginlist file is in uppercase
  added plugin anchor links to news

res/template.txt
  added category links to each category page and a "back to top" link